### PR TITLE
Have a string including CR to match

### DIFF
--- a/lib/rspec/match_fuzzy.rb
+++ b/lib/rspec/match_fuzzy.rb
@@ -3,16 +3,19 @@
 require 'rspec'
 
 RSpec::Matchers.define :match_fuzzy do |expected|
+  scrub = lambda { |s|
+    s.strip.gsub(/^\s+/, '').gsub(/[[:blank:]]+/, "\s").gsub(/\n+/, "\n").gsub(/\s+$/, '')
+  }
+
   expected = expected.to_s
   match do |actual|
     actual = actual.to_s
-    actual.strip.gsub(/[[:blank:]]+/, '').gsub(/\n+/, "\n") == expected.strip.gsub(/[[:blank:]]+/, '').gsub(/\n+/, "\n")
+    scrub[actual] == scrub[expected]
   end
 
   failure_message do |actual|
-    actual = actual.to_s
-    actual_normalized = actual.strip.gsub(/^\s+/, '').gsub(/[[:blank:]]+/, "\s").gsub(/\n+/, "\n").gsub(/\s+$/, '')
-    expected_normalized = expected.strip.gsub(/^\s+/, '').gsub(/[[:blank:]]+/, "\s").gsub(/\n+/, "\n").gsub(/\s+$/, '')
+    actual_normalized = scrub[actual.to_s]
+    expected_normalized = scrub[expected]
 
     message = <<~EOS.strip
       expected: #{expected_normalized.inspect}

--- a/spec/rspec/match_fuzzy_spec.rb
+++ b/spec/rspec/match_fuzzy_spec.rb
@@ -60,6 +60,12 @@ describe 'match_fuzzy' do
     end
   end
 
+  context 'when either contains a carriage return' do
+    specify do
+      expect("London Bridge\r\nIs Broken down").to match_fuzzy "London Bridge\nIs Broken down"
+    end
+  end
+
   context 'when not match' do
     specify do
       expect do


### PR DESCRIPTION
Thank you for bumping up the gem with the support for the recent RSpec.🙏

As per the testcase I included into `match_fuzzy_spec.rb`:

```rb
expect("London Bridge\r\nIs Broken down").to match_fuzzy "London Bridge\nIs Broken down"
```

when either string has a CR (carriage return) character, the match fails with an empty diff output.

Looking into `match_fuzzy.rb`, the code to clean up whitespaces for matching and one to generate the diff are different from each other. I have rolled them up to a common procedure to make them DRY as well as to fix the issue above.

I'd be grateful if you could merge this. Thanks!